### PR TITLE
feat: add config encounter milestones discord notification

### DIFF
--- a/dashboard/config.html
+++ b/dashboard/config.html
@@ -181,6 +181,24 @@
                                 <label for="user_id">User/Role ID</label>
                                 <input id="user_id" class="form-control">
                             </div>
+                            <br />
+                            <div class="custom-switch">
+                              <input type="checkbox" id="encounter_milestones_enable" />
+                              <label for="encounter_milestones_enable"
+                                >Enable Pokemon Encounter Milestones
+                              </label>
+                            </div>
+                            <div id="option_encounter_milestones">
+                              <br />
+                              <label for="encounter_milestones_interval">Interval</label>
+                              <input
+                                id="encounter_milestones_interval"
+                                style="width: 100px"
+                                min="1"
+                                type="number"
+                                class="form-control"
+                              />
+                            </div>
                         </div>
                     </div>
                     <div class="card">

--- a/dashboard/js/config.js
+++ b/dashboard/js/config.js
@@ -65,6 +65,7 @@ function updateOptionVisibility() {
     $('#option_auto_catch').hide();
     $('#option_webhook').hide();
     $('#option_ping_user').hide();
+    $("#option_encounter_milestones").hide();
     $('#option_primo').hide();
     $('#option_grotto').hide();
     $('#option_ot_override').hide();
@@ -122,6 +123,10 @@ function updateOptionVisibility() {
 
     if ($('#ping_user').prop('checked')) {
         $('#option_ping_user').show();
+    }
+
+    if ($("#encounter_milestones_enable").prop("checked")) {
+        $("#option_encounter_milestones").show();
     }
 
     if ($('#ot_override').prop('checked')) {


### PR DESCRIPTION
### Description
Discord notification pokemon species encounter milestone 

Required

- Enable Discord Webhook
- Enable Pokemon Encounter Milestones
- Default interval is 500 
![image](https://github.com/user-attachments/assets/58674693-934f-46a1-adb7-7de880e8133c)

### Changes
- Socket file webhook logic check notification inspire from [40 Cakes pokebot-gen3 ](https://github.com/40Cakes/pokebot-gen3)
- Stats file structure mapping via game version with trainer id when found shiny will reset to 0
![image](https://github.com/user-attachments/assets/afddf8bb-2f42-4a0a-b695-5c634505d44e)

### Notes
Tested on Pokemon Platinum Japan version work as well
![image](https://github.com/user-attachments/assets/2e707b53-884d-45fa-8e90-66e57865749f)


