### PR TITLE
Fix "Attempt to index a nil value" crash during breeding.

### DIFF
--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -282,7 +282,7 @@ function check_hatching_eggs()
     if #party == 6 then
         local has_egg = false
         
-        for _, is_egg in ipairs(new_eggs) do
+        for _, is_egg in ipairs(party_egg_states) do
             if is_egg then
                 has_egg = true
                 break


### PR DESCRIPTION
Replace old variable name in helpers.lua to fix "Attempt to index a nil value" crash during breeding method

While breeding there's a constantly check for the current egg state of each party member to see if it's time to release all lvl 1 pokemon that weren't the target.

A variable "new_eggs" from a previous version of helpers.lua was renamed, but not everywhere. So it was being used in an ipairs call without being initialized. Simply replacing the `new_eggs` with `party_egg_states` fixes the "Attempt to index a nil value" crash.
![image](https://github.com/user-attachments/assets/d71637e3-f4c5-40c8-87b7-7becf4c4708c)
![image](https://github.com/user-attachments/assets/7bd809cc-43a8-4f5c-bcd3-da86b5f38851)


#61 might be a more comprehensive solution to more issues with the breeding method - but this fix is tested in my version of Platinum and resolves this specific crash issue.