### PR TITLE
Roamer fixes

### DIFF
--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------------
 -- General helper methods for bot functionality
--- Author: wyanido, storyzealot
+-- Author: wyanido
 -- Homepage: https://github.com/wyanido/pokebot-nds
 -----------------------------------------------------------------------------
 
@@ -246,7 +246,7 @@ end
 --- Presses A to allow the egg hatch animation to finish if it's currently happening
 function check_hatching_eggs()
     if emu.framecount() % 10 == 0 then
-        if _ROM.version == "HG" or _ROM.version == "SS" then
+        if _ROM.version == "HG" or _ROM.version == "SS" then -- HGSS needs to deny phone calls a lot of the time, so we use B instead
             press_button_async("B")
         else
             press_button_async("A")
@@ -257,6 +257,8 @@ function check_hatching_eggs()
 
     -- Check for egg hatching
     for i, is_egg in ipairs(current_egg_states) do
+        -- Eggs are already considered "hatched" as soon as the animation starts,
+        -- so we can tell if an egg is hatching when 'is_egg' has changed since last reference
         if party[i] then
             if party_egg_states[i] ~= is_egg then
                 clear_all_inputs()
@@ -289,7 +291,7 @@ function check_hatching_eggs()
 
         -- Only release hatched duds if all eggs are hatched
         if not has_egg then
-            print("No eggs left in the party; releasing hatched duds.")
+            print("Party has no room for eggs! Releasing last 5 Pokemon...")
             release_hatched_duds()
         end
     elseif not party then

--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -20,7 +20,7 @@ function update_party()
     local party_size = mbyte(pointers.party_count)
     local party_was_updated = false
 
-    for i = 1, 6, 1 do
+    for i = 1, 6 do
         local checksum = mword(pointers.party_data + 6 + _MON_BYTE_LENGTH * (i - 1))
         
         if i <= party_size then
@@ -232,7 +232,7 @@ end
 function get_party_egg_states()
     local eggs = {}
 
-    for i = 1, 6, 1 do
+    for i = 1, 6 do
         if party[i] then
             eggs[i] = party[i].isEgg
         else
@@ -260,10 +260,9 @@ function check_hatching_eggs()
         -- so we can tell if an egg is hatching when 'is_egg' has changed since last reference
         if party[i] and party_egg_states[i] ~= is_egg then
             clear_all_inputs()
-            
             print("Egg is hatching!")
             hatch_egg(i)
-            
+
             local is_target = pokemon.log_encounter(party[i])
             if is_target then
                 abort("Hatched a target Pokemon!")
@@ -277,23 +276,24 @@ function check_hatching_eggs()
     end
 
     party_egg_states = current_egg_states
-    
+
     -- Check party to see if it's clear of eggs
-    if #party == 6 then
+    if party and #party == 6 then  -- Added check for party being nil
         local has_egg = false
         
-        for _, is_egg in ipairs(new_eggs) do
+        for _, is_egg in ipairs(new_eggs or {}) do  -- Prevent nil case for new_eggs
             if is_egg then
                 has_egg = true
                 break
             end
         end
 
-        -- If no eggs are left and no target was found, release all Lv. 1 Pokemon from the party
         if not has_egg then
             print("Party has no room for eggs! Releasing last 5 Pokemon...")
             release_hatched_duds()
         end
+    elseif not party then
+        print("Error: Party is nil.")
     end
 end
 

--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------------
 -- General helper methods for bot functionality
--- Author: wyanido
+-- Author: wyanido, storyzealot
 -- Homepage: https://github.com/wyanido/pokebot-nds
 -----------------------------------------------------------------------------
 

--- a/lua/methods/gen_iv.lua
+++ b/lua/methods/gen_iv.lua
@@ -450,6 +450,10 @@ function mode_roamers()
     if not config.ot_override then
         abort("You must set your TID/SID override before you can start.") -- Prevents mode from beginning if override is not set.
     end
+    
+    if mon.name == "Unown" then
+        abort("Please clear the journal and then save to resume.") -- Sometimes the roamer is read as an Unown due to the journal. This will stop pointless resets.
+    end
 
     while not data do
         data = pokemon.read_data(pointers.roamer, is_unencrypted)

--- a/lua/methods/gen_iv.lua
+++ b/lua/methods/gen_iv.lua
@@ -450,10 +450,6 @@ function mode_roamers()
     if not config.ot_override then
         abort("You must set your TID/SID override before you can start.") -- Prevents mode from beginning if override is not set.
     end
-    
-    if mon.name == "Unown" then
-        abort("Please clear the journal and then save to resume.") -- Sometimes the roamer is read as an Unown due to the journal. This will stop pointless resets.
-    end
 
     while not data do
         data = pokemon.read_data(pointers.roamer, is_unencrypted)
@@ -476,7 +472,11 @@ function mode_roamers()
     end
 
     local is_target = pokemon.log_encounter(mon)
-
+    
+    if mon.name == "Unown" then
+        abort("Please clear the journal and then save to resume.") -- The journal is read as 'Unown'. This will stop pointless resets.
+    end
+    
     if is_target then
         abort(mon.name .. " is a target!")
     else

--- a/lua/methods/gen_iv.lua
+++ b/lua/methods/gen_iv.lua
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------------
 -- General bot methods for gen 4 games (DPPt, HGSS)
--- Author: wyanido
+-- Author: wyanido, storyzealot
 -- Homepage: https://github.com/wyanido/pokebot-nds
 -----------------------------------------------------------------------------
 
@@ -447,6 +447,10 @@ function mode_roamers()
     local a_cooldown = 0
     local is_unencrypted = _ROM.version ~= "PL" -- Only Platinum encrypts roamer data after generating it 
 
+    if not config.ot_override then
+        abort("Please set your TID/SID in the override before you begin.") -- Prevents mode from beginning if override is not set.
+    end
+
     while not data do
         data = pokemon.read_data(pointers.roamer, is_unencrypted)
 
@@ -461,12 +465,16 @@ function mode_roamers()
     end
 
     local mon = pokemon.parse_data(data, true)
+
+    if config.ot_override then
+        mon.otSID = tonumber(config.sid_override) --SID is not generated during initial encounter. This will prevent false flagging.
+    end
+
     local is_target = pokemon.log_encounter(mon)
 
     if is_target then
         abort(mon.name .. " is a target!")
     else
-        print(mon.name .. " was not a target, resetting...")
         soft_reset()
     end
 end

--- a/lua/methods/gen_iv.lua
+++ b/lua/methods/gen_iv.lua
@@ -448,7 +448,7 @@ function mode_roamers()
     local is_unencrypted = _ROM.version ~= "PL" -- Only Platinum encrypts roamer data after generating it 
 
     if not config.ot_override then
-        abort("Please set your TID/SID in the override before you begin.") -- Prevents mode from beginning if override is not set.
+        abort("You must set your TID/SID override before you can start.") -- Prevents mode from beginning if override is not set.
     end
 
     while not data do
@@ -467,7 +467,8 @@ function mode_roamers()
     local mon = pokemon.parse_data(data, true)
 
     if config.ot_override then
-        mon.otSID = tonumber(config.sid_override) --SID is not generated during initial encounter. This will prevent false flagging.
+        mon.otSID = tonumber(config.sid_override) -- SID is not generated during initial encounter. This will prevent false flagging.
+        mon.otID = tonumber(config.sid_override) -- Sets the ID as well for those who are overriding it from their usual TID.
     end
 
     local is_target = pokemon.log_encounter(mon)

--- a/lua/methods/gen_v.lua
+++ b/lua/methods/gen_v.lua
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------------
 -- General bot methods for gen 5 games (BW, B2W2)
--- Author: wyanido
+-- Author: wyanido, storyzealot
 -- Homepage: https://github.com/wyanido/pokebot-nds
 -----------------------------------------------------------------------------
 
@@ -393,49 +393,178 @@ function mode_phenomenon_encounters()
 end
 
 function mode_daycare_eggs()
+    print("Start of Egg Hatching.")
+    print("Ensure your key menu item has Bicycle selected.")
+
     local function mount_bike()
         if mbyte(pointers.bike) ~= 1 then 
             press_sequence("Y")
         end
     end
-    
+
     local function check_and_collect_egg()
-        -- Don't bother with additional eggs if party is full
-        if #party == 6 or mdword(pointers.daycare_egg) == 0 then
+        print("Checking for eggs...")
+
+        -- Don't bother if party is full
+        if #party == 6 then
+            print("Party is full, cannot collect more eggs.")
             return
         end
 
         print("That's an egg!")
-
-        move_to({x=748}, check_hatching_eggs)
-        move_to({z=557}, check_hatching_eggs)
+        move_to({x = 748}, check_hatching_eggs)
+        move_to({z = 557}, check_hatching_eggs)
         clear_all_inputs()
 
         local party_count = #party
+        print("Waiting for a party change...")
         while #party == party_count do
             progress_text()
         end
+        print("Party has changed. New count: " .. #party)
 
         -- Return to long horizontal path 
+        print("Returning to previous position...")
         press_sequence(30, "B")
-        move_to({z=563}, check_hatching_eggs)
+        move_to({z = 563}, check_hatching_eggs)
     end
 
-    -- Initialise party state for future reference
+    print("Processing frame...")
     process_frame()
     party_egg_states = get_party_egg_states()
+    print("Initial party egg states acquired.")
 
+    -- Uncomment for debugging bike mount
     -- mount_bike()
-    move_to({z=563}, check_hatching_eggs)
-    
+
+    move_to({z = 563}, check_hatching_eggs)
+
     while true do
-        move_to({x=680}, check_hatching_eggs)
-        move_to({x=748}, check_hatching_eggs)
+        print("Moving to x=680...")
+        move_to({x = 680}, check_hatching_eggs)
+
+        print("Moving to x=748...")
+        move_to({x = 748}, check_hatching_eggs)
         check_and_collect_egg()
-        move_to({x=759}, check_hatching_eggs)
-        move_to({x=748}, check_hatching_eggs)
+
+        print("Moving to x=759...")
+        move_to({x = 759}, check_hatching_eggs)
+
+        print("Moving back to x=748...")
+        move_to({x = 748}, check_hatching_eggs)
         check_and_collect_egg()
+
+        -- Check if the party is full and if there are no eggs remaining
+        if #party == 6 then  -- Check if party is full
+            local current_egg_states = get_party_egg_states()  -- Refresh the egg states
+
+            -- Only release if there are no eggs left in the party
+            local has_egg = false
+            for _, is_egg in ipairs(current_egg_states) do
+                if is_egg then
+                    has_egg = true
+                    break
+                end
+            end
+            
+            if not has_egg then
+                print("All eggs hatched. Releasing hatched duds...")
+                release_hatched_duds()
+            else
+                print("Some eggs are still unhatched. Not releasing.")
+            end
+        end
     end
+end
+
+-- Navigates to the Route 3 daycare and releases all hatched Pokemon in the party
+function release_hatched_duds()
+    print("Releasing eggs...")
+
+    local function release(i)
+        print("Releasing Pokemon at index: " .. i)
+        local x = 40 * ((i - 1) % 2 + 1)
+        local y = 72 + 30 * math.floor((i - 1) / 2)
+
+        touch_screen_at(x, y) -- Select Pokemon
+        print("Selected Pokemon at: (" .. x .. ", " .. y .. ")")
+        wait_frames(30)
+        touch_screen_at(211, 121) -- RELEASE
+        print("Tapped RELEASE")
+        wait_frames(30)
+        touch_screen_at(220, 110) -- YES
+        print("Confirmed RELEASE")
+        press_sequence(60, "B", 20, "B", 20) -- Bye-bye!
+        print("Released Pokémon.")
+    end
+
+    move_to({x = 748}) -- Move to staircase
+    move_to({z = 557}) -- Move to the door
+    move_to({x = 749, z = 556})
+    print("Navigating to daycare lady at desk...")
+
+    -- Walk to daycare lady at desk
+    while game_state.map_header ~= 323 do
+        hold_button("Up")
+    end
+
+    release_button("Up")
+
+    -- Walk to PC
+    print("Moving to PC...")
+    hold_button("B")
+    move_to({z = 9})
+    move_to({x = 9})
+    hold_button("Up")
+    wait_frames(10)
+    release_button("Up")
+    wait_frames(10)
+    release_button("B")
+
+    press_sequence("A", 140, "A", 120, "A", 110, "A", 60)
+    print("Navigating through PC options...")
+    press_sequence("Down", 5, "Down", 5, "A", 110)
+
+    touch_screen_at(45, 175)
+    wait_frames(60)
+
+    -- Release party in reverse order so the positions don't shuffle to fit empty spaces
+    for i = #party, 1, -1 do
+        if pokemon.is_hatched_dud(party[i]) then
+            release(i)
+        else
+            print("Pokémon at index " .. i .. " is not a hatched dud.")
+        end
+    end
+
+    press_sequence("B", 25, "B", 30, "B", 30, "B", 150, "B", 90) -- Exit PC
+
+    -- Exit daycare
+    print("Exiting daycare...")
+    hold_button("B")
+    move_to({x = 6})  -- Move to the door's x-coordinate
+    move_to({z = 13}) -- Move to the door's z-coordinate
+
+    -- Move down to fully exit the daycare
+    hold_button("Down") -- Hold down to step down
+    wait_frames(10)     -- Wait for a moment to allow for the action
+    release_button("Down") -- Release the down button
+
+    -- Wait until the map changes
+    while game_state.map_header ~= 323 do
+        emu.yield() -- Allow time for the game to process the input
+    end
+
+    -- Stop holding buttons once the map changes
+    release_button("B")
+    print("Exited daycare.")
+
+    -- Perform actions after exiting daycare
+    print("Getting on bike...")
+    press_sequence(180, "Y", 30, "A", 30) -- Press Y (and A in case of multiple key items)
+    move_to({z = 557}) -- Move to the desired z-coordinate after exiting
+    move_to({x = 748}) -- Move to the desired x-coordinate
+    move_to({z = 563}) -- Move to final z-coordinate
 end
 
 function mode_roamers()
@@ -473,73 +602,6 @@ function mode_roamers()
         print(mon.name .. " was not a target, resetting...")
         soft_reset()
     end
-end
-
---- Navigates to the Route 3 daycare and releases all hatched Pokemon in the party
-function release_hatched_duds()
-    local function release(i)
-        local x = 40 * ((i - 1) % 2 + 1)
-        local y = 72 + 30 * math.floor((i - 1) / 2)
-
-        touch_screen_at(x, y) -- Select Pokemon
-        wait_frames(30)
-        touch_screen_at(211, 121) -- RELEASE
-        wait_frames(30)
-        touch_screen_at(220, 110) -- YES
-        press_sequence(60, "B", 20, "B", 20) -- Bye-bye!
-    end
-
-    move_to({x=748}) -- Move to staircase
-    move_to({z=557}) -- Move to the door
-    move_to({x=749,z=556})
-    
-    -- Walk to daycare lady at desk
-    while game_state.map_header ~= 323 do
-        hold_button("Up")
-    end
-
-    release_button("Up")
-
-    -- Walk to PC
-    hold_button("B")
-    move_to({z=9})
-    move_to({x=9})
-    hold_button("Up")
-    wait_frames(10)
-    release_button("Up")
-    wait_frames(10)
-    release_button("B")
-    
-    press_sequence("A", 140, "A", 120, "A", 110, "A", 60)
-    press_sequence("Down", 5, "Down", 5, "A", 110)
-
-    touch_screen_at(45, 175)
-    wait_frames(60)
-
-    -- Release party in reverse order so the positions don't shuffle to fit empty spaces
-    for i = #party, 1, -1 do
-        if pokemon.is_hatched_dud(party[i]) then
-            release(i)
-        end
-    end
-
-    press_sequence("B", 25, "B", 30, "B", 30, "B", 150, "B", 90) -- Exit PC
-    
-    -- Exit daycare
-    hold_button("B")
-    move_to({x=6})
-    move_to({z=13})
-    
-    while game_state.map_header ~= 321 do
-        hold_button("Down")
-    end
-
-    release_button("B")
-    release_button("Down")
-    press_sequence(180, "Y", 30)
-    move_to({z=557})
-    move_to({x=748})
-    move_to({z=563})
 end
 
 --- Returns the current stage of the battle as a simple string

--- a/lua/methods/global.lua
+++ b/lua/methods/global.lua
@@ -539,7 +539,7 @@ function mode_static_encounters()
     while not game_state.in_battle do
         if game_state.map_name == "Dreamyard" then
             hold_button("Right")
-        elseif game_state.map_name == "Spear Pillar" then
+        elseif game_state.map_name == "Spear Pillar" or "Hall of Origin" then
             hold_button("Up")
         end
 


### PR DESCRIPTION
Fixes the issue where people were getting false flagged.

This is due to the SID not being generated until after the initial encounter so it was being read as 00000.

The user will now be required to set the override before the mode can begin.

The journal for the Sinnoh games gets read as an Unown, so there is a stop in place to avoid pointless resets.

I have also begun adding to the wiki so now there at least a page for the roamers mode.

This has not been tested for HGSS or the Gen 5 games, but there should be no conflict.