### PR TITLE
fix(check_hatching_eggs): Replace undeclared variable.

### DIFF
--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -282,7 +282,7 @@ function check_hatching_eggs()
     if #party == 6 then
         local has_egg = false
         
-        for _, is_egg in ipairs(new_eggs) do
+        for _, is_egg in ipairs(party_egg_states) do
             if is_egg then
                 has_egg = true
                 break


### PR DESCRIPTION
`new_eggs` was not declared anywhere.

Made this change and was able to successfully shiny hunt Phione.

![image](https://github.com/user-attachments/assets/beeaaa19-9c16-4d19-a7c9-dcbf5863fab0)
