### PR TITLE
Fixed pickup by adding a delay before Start menu

### DIFF
--- a/lua/methods/global.lua
+++ b/lua/methods/global.lua
@@ -292,6 +292,7 @@ function process_wild_encounter()
     end
 
     if config.pickup then
+        wait_frames(79)
         do_pickup()
     end
 end


### PR DESCRIPTION
Pickup is currently broken because the script attempts to press X to open the start menu before the battle fade ends.

A delay of 79 frames is added to the end of battle check to allow the fade animation to end and have the Start menu input register in game. 78 frames will not work on Platinum (bug will still exist), and are untested in other games.

The delay is not added to the pickup method so that the pickup method can be called out of sequence with battling.

The delay (79 frames) is tested in the following and are working:
- Platinum (USA)
- Soul Silver (USA)
- Black (USA)
- Black 2 (USA)