### PR TITLE
Fixed Pickup & Replace lead Pokemon post-battle by adding a delay

### DIFF
--- a/lua/methods/global.lua
+++ b/lua/methods/global.lua
@@ -291,6 +291,8 @@ function process_wild_encounter()
         end
     end
 
+    wait_frames(90)
+    
     if config.pickup then
         do_pickup()
     end


### PR DESCRIPTION
Pickup & Replacing lead Pokemon is currently broken because the script attempts to press X to open the start menu before the battle fade ends.

The minimum delay that works across all generations is 79, but through testing, delays 79 and 80 sometimes encounter the same issue. Hence, to be safe, a delay of 90 is used.

Refer to PR #74 for more details.